### PR TITLE
Refactor inline+naming

### DIFF
--- a/Sources/SwiftWyhash/SwiftWyhash.swift
+++ b/Sources/SwiftWyhash/SwiftWyhash.swift
@@ -1,20 +1,16 @@
-public struct WyhashGenerator: RandomNumberGenerator {
-    private var seed : UInt64
+public struct Wyhash64: RandomNumberGenerator {
+    private var state : UInt64
 
-    private static let multiplier1 : UInt64 = 0xa3b195354a39b70d
-    private static let multiplier2 : UInt64 = 0x1b03738712fad5c9
-    private static let increment : UInt64 = 0x60bee2bee120fc15
-
-    init(userSeed : UInt64) {
-        seed = userSeed;
+    init(seed : UInt64) {
+        self.state = seed
     }
 
     public mutating func next() -> UInt64 {
-        seed &+= WyhashGenerator.increment
-        let fullmult1 = seed.multipliedFullWidth(by: WyhashGenerator.multiplier1)
-        let m1 = fullmult1.high ^ fullmult1.low;
-        let fullmult2 = m1.multipliedFullWidth(by: WyhashGenerator.multiplier2)
-        let m2 = fullmult2.high ^ fullmult2.low;
-        return m2;
+        self.state &+= 0x60bee2bee120fc15
+        let t1 = self.state.multipliedFullWidth(by: 0xa3b195354a39b70d)
+        let m1 = t1.high ^ t1.low
+        let t2 = m1.multipliedFullWidth(by: 0x1b03738712fad5c9)
+        let m2 = t2.high ^ t2.low
+        return m2
     }
 }

--- a/Tests/SwiftWyhashTests/SwiftWyhashTests.swift
+++ b/Tests/SwiftWyhashTests/SwiftWyhashTests.swift
@@ -3,14 +3,14 @@ import XCTest
 
 final class SwiftWyhashTests: XCTestCase {
     func testBasic() {
-        var gen = WyhashGenerator(userSeed: 0)
+        var gen = Wyhash64(seed: 0)
         XCTAssertEqual(gen.next(), 6661202149082483300)
         XCTAssertEqual(gen.next(), 13322404298164966600)
         XCTAssertEqual(gen.next(), 10710867605997789043)
     }
     
     func testShuffled() {
-        var g = WyhashGenerator(userSeed: 0)
+        var g = Wyhash64(userSeed: 0)
         XCTAssertEqual((1...10).shuffled(using: &g),
                        [1, 6, 2, 8, 4, 7, 5, 10, 3, 9])
     }

--- a/Tests/SwiftWyhashTests/SwiftWyhashTests.swift
+++ b/Tests/SwiftWyhashTests/SwiftWyhashTests.swift
@@ -10,7 +10,7 @@ final class SwiftWyhashTests: XCTestCase {
     }
     
     func testShuffled() {
-        var g = Wyhash64(userSeed: 0)
+        var g = Wyhash64(seed: 0)
         XCTAssertEqual((1...10).shuffled(using: &g),
                        [1, 6, 2, 8, 4, 7, 5, 10, 3, 9])
     }


### PR DESCRIPTION
I see you refer to this generator as `wyhash64` in [your article](https://lemire.me/blog/2019/03/19/the-fastest-conventional-random-number-generator-that-can-pass-big-crush/). It makes sense to me to rename the implementation to `Wyhash64`. This makes it follow the conventional naming like [`SplitMix64`](https://github.com/apple/swift/commit/d2a47db71aa57c33feb29001a3428ba8812b9078) or `Xoshiro128`.

I took the liberty to remove few semicolons that remained from the C port and inlined the constants for more compact implementation. 