### PR TITLE
Test generating random number sequence

### DIFF
--- a/Tests/SwiftWyhashTests/SwiftWyhashTests.swift
+++ b/Tests/SwiftWyhashTests/SwiftWyhashTests.swift
@@ -17,8 +17,7 @@ final class SwiftWyhashTests: XCTestCase {
 
     func testNumberSequence() {
         var numbers = sequence(state: Wyhash64(seed: 0)) {
-            (g: inout Wyhash64) -> Int? in
-            return Int.random(in: Int.min...Int.max, using: &g)
+            return Int.random(in: Int.min...Int.max, using: &$0)
         }
         // Array initializer takes a copy of numbers value,
         // because `UnfoldSequence` and `Wyhash64` are both value types.

--- a/Tests/SwiftWyhashTests/SwiftWyhashTests.swift
+++ b/Tests/SwiftWyhashTests/SwiftWyhashTests.swift
@@ -8,15 +8,33 @@ final class SwiftWyhashTests: XCTestCase {
         XCTAssertEqual(gen.next(), 13322404298164966600)
         XCTAssertEqual(gen.next(), 10710867605997789043)
     }
-    
+
     func testShuffled() {
         var g = Wyhash64(seed: 0)
         XCTAssertEqual((1...10).shuffled(using: &g),
                        [1, 6, 2, 8, 4, 7, 5, 10, 3, 9])
     }
 
+    func testNumberSequence() {
+        var numbers = sequence(state: Wyhash64(seed: 0)) {
+            (g: inout Wyhash64) -> Int? in
+            return Int.random(in: Int.min...Int.max, using: &g)
+        }
+        // Array initializer takes a copy of numbers value,
+        // because `UnfoldSequence` and `Wyhash64` are both value types.
+        XCTAssertEqual(Array(numbers.prefix(2)),
+                       [6661202149082483300, -5124339775544585016])
+        XCTAssertEqual(numbers.next(), 6661202149082483300)
+
+        XCTAssertEqual(Array(numbers.prefix(2)),
+                       [-5124339775544585016, -7735876467711762573])
+        XCTAssertEqual(numbers.next(), -5124339775544585016)
+        XCTAssertEqual(numbers.next(), -7735876467711762573)
+    }
+
     static var allTests = [
         ("testBasic", testBasic),
         ("testShuffled", testShuffled),
+        ("testNumberSequence", testNumberSequence),
     ]
 }


### PR DESCRIPTION
Use `sequence` (returns `UnfoldSequence` type), to generate a random `Sequence` of `Int`s.